### PR TITLE
Add chain function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ node_js:
 - 6
 - 7
 cache: yarn
+script:
+- yarn run eslint
+- yarn run flow
+- yarn run cover
 deploy:
   provider: npm
   email: joe.grund@intel.com

--- a/source/maybe.js
+++ b/source/maybe.js
@@ -49,6 +49,9 @@ export const map = <A, B>(fn: (A) => B, mA: Maybe<A>): Maybe<B> =>
 export const withDefault = <A, Ma: Maybe<A>>(defaultFn: () => A, mA: Ma): A =>
   mA instanceof Nothing ? defaultFn() : mA.value;
 
+export const chain = <A, Ma: Maybe<A>>(fn: (A) => Ma, mA: Ma): Ma =>
+  mA instanceof Nothing ? mA : fn(mA.value);
+
 export const matchWith = <A, B>(
   cases: {| Just(a: A): B, Nothing(): B |},
   mA: Maybe<A>

--- a/test/maybe.test.js
+++ b/test/maybe.test.js
@@ -101,4 +101,36 @@ describe('Maybe', () => {
       expect(matchFn(maybe.of('p'))).toBe('bap');
     });
   });
+
+  describe('chain', () => {
+    it('should chain with nothing', () => {
+      const key = 'name';
+      const options = ['street', 'phone', 'city', 'state', 'zip'];
+
+      const result = maybe.chain(
+        x => {
+          const token = options.find(val => val === x);
+          return !token ? maybe.ofNothing() : maybe.ofJust(token);
+        },
+        maybe.of(key)
+      );
+
+      expect(result instanceof maybe.Nothing).toBe(true);
+    });
+
+    it('should chain with a value', () => {
+      const key = 'name';
+      const options = ['street', 'phone', 'city', 'name', 'state', 'zip'];
+
+      const result = maybe.chain(
+        x => {
+          const token = options.find(val => val === x);
+          return !token ? maybe.ofNothing() : maybe.ofJust(token);
+        },
+        maybe.of(key)
+      );
+
+      expect(result).toEqual(maybe.ofJust('name'));
+    });
+  });
 });


### PR DESCRIPTION
Fixes #3.

We should be able to chain / flatMap Maybe types. For this reason, add a
"chain" method to maybe. This will allow us to get back a Nothing or
Just, which can then be mapped or pushed into a number of different
operations.

Signed-off-by: Will Johnson <william.c.johnson@intel.com>